### PR TITLE
Allow delegation of parties endpoint through registrar_id path

### DIFF
--- a/config/satellite.yml
+++ b/config/satellite.yml
@@ -119,3 +119,7 @@ parties:
       -----BEGIN CERTIFICATE-----
       <HappyPets Certificate>
       -----END CERTIFICATE-----
+
+associates:
+  "EU.EORI.OTHER-SATELLITE":
+    url: "https://other-satellite.example.com"


### PR DESCRIPTION
By adding query parameter registrar_id with a comma separated list of satellite ids it is no possible to have the query be delegate to associated satellites.  This first element in the registrar_id path must be the first satellite to target.

As example, the following call is done to eu.euro.nllocalsat:

```
https://nllocalsat.example.com/parties?eori=EU.EORI.NLDATAOWNER&registrar_id=EU.EURO.NLLOCALSAT,EU.EURO.NLFRIENDLYSAT
```

this satellite sees the registrar_id parameter is a path, adjusts it and calls its friendly neighbor:

```
https://nlfriendlysat.example.com/parties?eori=eu.eori.nldataowner&registrar_id=EU.EURO.NLFRIENDLYSAT
```

the nlfriendlysat satellite sees they are at the end of the path and responds to the /parties query.

Associated satellites are added to satellite.yml:

```yaml
associates:
  "EU.EURO.NLFRIENDLYSAT":
    url: "https://nlfriendlysat.example.com"
```

and they should include the calling satellite as a party.